### PR TITLE
Build script to pair mentors and collabies in CodeSandbox and link to it

### DIFF
--- a/session-docs/mentor-linkedin-review.md
+++ b/session-docs/mentor-linkedin-review.md
@@ -12,8 +12,9 @@ Please have review and [rubric](https://the-collab-lab.slack.com/archives/C01L13
 
 ---
 
-Linkedin Review Pairings: 
-
+Linkedin Review Pairings:
+[comment]: <> (Populate using the values in this CodeSandbox: https://codesandbox.io/s/career-lab-pairings-u1qmj?file=/src/App.js)
+[comment]: <> (TODO: move this script into this project somehow)
 | Collabie | Mentor |
 | ---- | ---- |
 | ---- | ---- |

--- a/session-docs/mock-interview-job-fit.md
+++ b/session-docs/mock-interview-job-fit.md
@@ -28,7 +28,8 @@ The interviews will run a maximum of 1 hour, including time for you to ask quest
 ---
 
 Job-Fit Interview Pairings:
-
+[comment]: <> (Populate using the values in this CodeSandbox: https://codesandbox.io/s/career-lab-pairings-u1qmj?file=/src/App.js)
+[comment]: <> (TODO: move this script into this project somehow)
 | Collabie | Mentor |
 | ---- | ---- |
 | ---- | ---- |

--- a/session-docs/mock-interview-technical.md
+++ b/session-docs/mock-interview-technical.md
@@ -26,7 +26,8 @@ The interviews will run a maximum of 1 hour, including time for you to ask quest
 ---
 
 Technical Interview Pairings:
-
+[comment]: <> (Populate using the values in this CodeSandbox: https://codesandbox.io/s/career-lab-pairings-u1qmj?file=/src/App.js)
+[comment]: <> (TODO: move this script into this project somehow)
 | Collabie | Mentor |
 | ---- | ---- |
 | ---- | ---- |

--- a/session-docs/pair-interview-practice.md
+++ b/session-docs/pair-interview-practice.md
@@ -14,8 +14,8 @@ Once you've met and practiced, check the box above next to your name to mark tha
 
 If you have questions or comments, please don't hesitate to reach out in [#career-lab-spring-2021](https://the-collab-lab.slack.com/archives/C022D9Z0QD7)!
 
-Interview Practice Partners: 
-
+Interview Practice Partners:
+[comment]: <> (TODO: need script to automate pairing. Must include pairing members of the same region together. )
 | Collabie | Collabie |
 | ---- | ---- |
 | ---- | ---- |


### PR DESCRIPTION
# Description

[This CodeSandbox script: Career Lab Pairings](https://codesandbox.io/s/career-lab-pairings-u1qmj?file=/src/App.js) will pair mentors and collabies for the following sessions and will return markdown that can be copy/pasted into the Career Lab markdown files: 

- Linkedin Review Pairs
- Job Fit Interview Pairs
- Technical Interview Pairs


## Todos: 
- [ ] Would love for this CodeSandox script to somehow live in the project, run automatically, and populate the .md files. 
- [ ] Make the script code WAY better and cleaner. Stacie threw it together SUPER quick and is NOT proud of it 😅 
- [ ] Need a script that will pair Collabies for Pair Interview Practice, but it must pair members of the same region together and handle if there is only one of a region. Will need to tap into GraphCMS for this. 